### PR TITLE
Rely on latest bouncycastle implementation. 

### DIFF
--- a/jtrust-lib/pom.xml
+++ b/jtrust-lib/pom.xml
@@ -58,11 +58,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcprov-jdk15on</artifactId>
+			<artifactId>bcprov-jdk18on</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcpkix-jdk15on</artifactId>
+			<artifactId>bcpkix-jdk18on</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/jtrust-lib/src/main/java/be/fedict/trust/crl/CrlTrustLinker.java
+++ b/jtrust-lib/src/main/java/be/fedict/trust/crl/CrlTrustLinker.java
@@ -32,6 +32,7 @@ import java.security.cert.X509Certificate;
 import java.util.Date;
 
 import org.bouncycastle.asn1.ASN1Enumerated;
+import org.bouncycastle.asn1.ASN1IA5String;
 import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.ASN1OctetString;
@@ -268,7 +269,7 @@ public class CrlTrustLinker implements TrustLinker {
 					LOGGER.debug("not a uniform resource identifier");
 					continue;
 				}
-				DERIA5String derStr = DERIA5String.getInstance(name.getName());
+				ASN1IA5String derStr = ASN1IA5String.getInstance(name.getName());
 				String str = derStr.getString();
 				if (false == str.startsWith("http")) {
 					/*

--- a/jtrust-lib/src/main/java/be/fedict/trust/ocsp/OcspTrustLinker.java
+++ b/jtrust-lib/src/main/java/be/fedict/trust/ocsp/OcspTrustLinker.java
@@ -33,6 +33,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.apache.commons.codec.digest.DigestUtils;
+import org.bouncycastle.asn1.ASN1IA5String;
 import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.DEROctetString;
@@ -325,7 +326,7 @@ public class OcspTrustLinker implements TrustLinker {
 				LOGGER.debug("not a uniform resource identifier");
 				continue;
 			}
-			DERIA5String str = DERIA5String.getInstance(gn.getName());
+			ASN1IA5String str = ASN1IA5String.getInstance(gn.getName());
 			String accessLocation = str.getString();
 			LOGGER.debug("OCSP access location: {}", accessLocation);
 			URI uri = toURI(accessLocation);

--- a/jtrust-testpki/pom.xml
+++ b/jtrust-testpki/pom.xml
@@ -41,11 +41,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcprov-jdk15on</artifactId>
+			<artifactId>bcprov-jdk18on</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcpkix-jdk15on</artifactId>
+			<artifactId>bcpkix-jdk18on</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -142,12 +142,12 @@
 			</dependency>
 			<dependency>
 				<groupId>org.bouncycastle</groupId>
-				<artifactId>bcprov-jdk15on</artifactId>
+				<artifactId>bcprov-jdk18on</artifactId>
 				<version>${bouncycastle.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.bouncycastle</groupId>
-				<artifactId>bcpkix-jdk15on</artifactId>
+				<artifactId>bcpkix-jdk18on</artifactId>
 				<version>${bouncycastle.version}</version>
 			</dependency>
 			<dependency>
@@ -233,7 +233,7 @@
                 Also test 1.60,1.61,1.62,1.63,1.64,1.65,1.66,1.67,1.68,1.69 before releasing.
                 1.71,1.72,1.73 requires renaming the BouncyCastle artifacts to -jdk18on
                 -->
-		<bouncycastle.version>1.70</bouncycastle.version>
+		<bouncycastle.version>1.76</bouncycastle.version>
 		<jetty.version>9.4.51.v20230217</jetty.version>
 	</properties>
 </project>


### PR DESCRIPTION
* Bump bouncycastle from jdk15on to jdk18on and from version 1.70 to 1.76.

* Bouncycastle 1.75 removed deprecated lethod DERIA5String.getInstance(ASN1Encodable) using ASN1IA5String.getInstance(ASN1Encodable) instead